### PR TITLE
Install `tzdata` package if platform is `windows`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ packages = find:
 install_requires =
     aiohttp>=3.7
     backports.zoneinfo; python_version<"3.9"
+    tzdata; os_name=='nt'
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Since `neuro-config-client` is now used within the neuro-sdk, this extra dependency is required for Windows installations.

[why](https://peps.python.org/pep-0615/#sources-for-time-zone-data):
_not all systems ship a publicly accessible time zone database — notably Windows uses a different system for managing time zones — and so if available zoneinfo falls back to an installable first-party package, tzdata, available on PyPI_

We would also need to enable more tests options for this repo: cover other OS-es in CI - MacOS and Windows in addition to Linux.
I could do that in separate PR, wdyt?